### PR TITLE
Fix migration error, nil value from accumluators-1

### DIFF
--- a/alien-module/migrations/alien-module_0.2.2.lua
+++ b/alien-module/migrations/alien-module_0.2.2.lua
@@ -1,5 +1,5 @@
 for i, force in pairs(game.forces) do 
- if force.technologies["electric-energy-accumulators-1"].researched then 
+ if force.technologies["electric-energy-accumulators"].researched then 
    force.recipes["alien-accumulator"].enabled = true
  end
 end


### PR DESCRIPTION
Fix for migration error from entity naming issue. 

related to:
https://github.com/renoth/factorio-alien-module/issues/27
https://github.com/renoth/factorio-alien-module/issues/25

To reproduce Issue:
1. Make new game with mod enabled.
2. Save game, exit.
3. Disable mod, (game reloads).
4. Open saved game, (game removes entities correctly).
5. Save game, exit.
6. Enable mod, (game reloads).
7. Load saved game again (game initiates migration);

Migration fails, Error produced.
------------------------------------------------
alien-module/migrations/alien-module_0.2.2.lua:2: attempt to index field "electric-energy-accumluators-1" {a nil value}
stack traceback:
alien-module/migrations/alien-module_0.2.2.lua:2: in main chunk
------------------------------------------------

Results:
Returns to main screen, mod still enabled, but unable to load existing map from a save without the mod.

After fix:
Steps to reproduce no longer produce error. Game loads, mod works, and game can be saved with new mod data.
Was also able to start new game with mod enabled without error.