### PR TITLE
Add setting to disable ore conversion receipes

### DIFF
--- a/alien-module/locale/en/names.cfg
+++ b/alien-module/locale/en/names.cfg
@@ -131,3 +131,9 @@ alien-module=Kill aliens to get alien ore. Use alien ore to craft powerful modul
 [gui]
 module-upgraded=Alien Hyper Modules upgraded to level: __1__
 label=Hypermodule level: __1__ Killcount: __2__
+
+[mod-setting-name]
+alien-module-ore-conversion=Enable ore conversion receipes
+
+[mod-setting-description]
+alien-module-ore-conversion=Enable receipes to convert alien ore to any other ore

--- a/alien-module/prototypes/recipe/alien-module.lua
+++ b/alien-module/prototypes/recipe/alien-module.lua
@@ -11,70 +11,72 @@ data:extend({
 	}
 })
 
--- make iron ore from alien ore --
-data:extend({
-	{
-		type = "recipe",
-		name = "alien-ore-to-iron-ore",
-		enabled = true,
-		energy_required = 10,
-		ingredients = { { "artifact-ore", 1 } },
-		result = "iron-ore",
-		result_count = 5
-	}
-})
+if(settings.startup["alien-module-ore-conversion"].value) then
+	-- make iron ore from alien ore --
+	data:extend({
+		{
+			type = "recipe",
+			name = "alien-ore-to-iron-ore",
+			enabled = true,
+			energy_required = 10,
+			ingredients = { { "artifact-ore", 1 } },
+			result = "iron-ore",
+			result_count = 5
+		}
+	})
 
--- make copper ore from alien ore --
-data:extend({
-	{
-		type = "recipe",
-		name = "alien-ore-to-copper-ore",
-		enabled = true,
-		energy_required = 10,
-		ingredients = { { "artifact-ore", 1 } },
-		result = "copper-ore",
-		result_count = 5
-	}
-})
+	-- make copper ore from alien ore --
+	data:extend({
+		{
+			type = "recipe",
+			name = "alien-ore-to-copper-ore",
+			enabled = true,
+			energy_required = 10,
+			ingredients = { { "artifact-ore", 1 } },
+			result = "copper-ore",
+			result_count = 5
+		}
+	})
 
--- make stone ore from alien ore --
-data:extend({
-	{
-		type = "recipe",
-		name = "alien-ore-to-stone",
-		enabled = true,
-		energy_required = 10,
-		ingredients = { { "artifact-ore", 1 } },
-		result = "stone",
-		result_count = 5
-	}
-})
+	-- make stone ore from alien ore --
+	data:extend({
+		{
+			type = "recipe",
+			name = "alien-ore-to-stone",
+			enabled = true,
+			energy_required = 10,
+			ingredients = { { "artifact-ore", 1 } },
+			result = "stone",
+			result_count = 5
+		}
+	})
 
--- make uranium ore from alien ore --
-data:extend({
-	{
-		type = "recipe",
-		name = "alien-ore-to-uranium-ore",
-		enabled = true,
-		energy_required = 20,
-		ingredients = { { "artifact-ore", 2 } },
-		result = "uranium-ore",
-		result_count = 1
-	}
-})
+	-- make uranium ore from alien ore --
+	data:extend({
+		{
+			type = "recipe",
+			name = "alien-ore-to-uranium-ore",
+			enabled = true,
+			energy_required = 20,
+			ingredients = { { "artifact-ore", 2 } },
+			result = "uranium-ore",
+			result_count = 1
+		}
+	})
 
--- make coal from alien ore --
-data:extend({
-	{
-		type = "recipe",
-		name = "alien-ore-to-coal",
-		enabled = true,
-		energy_required = 10,
-		ingredients = { { "artifact-ore", 1 } },
-		result = "coal",
-		result_count = 5
-	}
-})
+	-- make coal from alien ore --
+	data:extend({
+		{
+			type = "recipe",
+			name = "alien-ore-to-coal",
+			enabled = true,
+			energy_required = 10,
+			ingredients = { { "artifact-ore", 1 } },
+			result = "coal",
+			result_count = 5
+		}
+	})
+end
 
 -- if bobs enemies is enabled, make conversion of alien artifacts possible
 if data.raw["item"]["alien-artifact"] ~= nil then

--- a/alien-module/settings.lua
+++ b/alien-module/settings.lua
@@ -1,0 +1,8 @@
+data:extend({
+	{
+		type = "bool-setting",
+		name = "alien-module-ore-conversion",
+		setting_type = "startup",
+		default_value = true
+	}
+})


### PR DESCRIPTION
This PR adds a setting to disable the alien ore to regular ore receipes.

For example useful for not accidentially crafting the most expensive stone furnaces in the world ;)