### PR TITLE
Fix entity.lua to not trigger Lia Diagnostics anymore

### DIFF
--- a/alien-module/prototypes/entity/entity.lua
+++ b/alien-module/prototypes/entity/entity.lua
@@ -119,7 +119,7 @@ alien_engine.horizontal_animation.layers[1].tint = alien_tint
 alien_engine.horizontal_animation.layers[1].hr_version.tint = alien_tint
 alien_engine.vertical_animation.layers[1].tint = alien_tint
 alien_engine.vertical_animation.layers[1].hr_version.tint = alien_tint
-alien_engine.fluid_usage_per_tick = 0.333,
+alien_engine.fluid_usage_per_tick = 0.333
 
 data:extend({ alien_engine })
 


### PR DESCRIPTION
The following line ends with a comma:
https://github.com/renoth/factorio-alien-module/blob/7c0c59adac9ee789ca6551f900c1f6093305a36f/alien-module/prototypes/entity/entity.lua#L122

---

This results in the following error in the following line:
> Only has 1 variables, but you set 2 values. *Lua Diagnostics. (redundant-value)*

https://github.com/renoth/factorio-alien-module/blob/7c0c59adac9ee789ca6551f900c1f6093305a36f/alien-module/prototypes/entity/entity.lua#L124

---

Removing the comma in line 122 at the end fixes this.
The change to line 178 was made by the GitHub web interface. I can't figure out how to prevent it, I guess it's due to the file not ending with a blank line.