### PR TITLE
fixes for quality and space age being required dependencies, they are now optional, although still unlisted

### DIFF
--- a/alien-module/changelog.txt
+++ b/alien-module/changelog.txt
@@ -1,4 +1,8 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.0.14
+  Changes:
+    - fixed quality and space age being required dependencies
+---------------------------------------------------------------------------------------------------
 Version: 2.0.13
   Changes:
     - fix quality hypermodule recipes not updating correctyl

--- a/alien-module/info.json
+++ b/alien-module/info.json
@@ -1,7 +1,7 @@
 {
   "name": "alien-module",
   "title": "Alien Loot Economy",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "author": "sensenmann",
   "homepage": "https://github.com/renoth/factorio-alien-module",
   "description": "Makes alien units drop alien ore that can be smelted into alien metal, which can be used for all sorts of alien empowered items.",

--- a/alien-module/prototypes/item/alien-module.lua
+++ b/alien-module/prototypes/item/alien-module.lua
@@ -58,11 +58,20 @@ for i = 1, 100, 1 do
 				consumption = levelbonus * 2,
 				speed = levelbonus,
 				productivity = levelbonus,
-				pollution = levelbonus * 2,
-				quality = levelbonus * quality_base_bonus
+				pollution = levelbonus * 2
 			},
 		},
 	})
+	-- adds the quality effect only if quality is enabled, this prevents quality from being a required dependency
+	if mods["quality"] and qualityenabled == true then
+		data.raw["module"]["alien-hyper-module-" .. i].effect = {
+			consumption = levelbonus * 2,
+			speed = levelbonus,
+			productivity = levelbonus,
+			pollution = levelbonus * 2,
+			quality = levelbonus * quality_base_bonus
+		}
+	end
 end
 
 

--- a/alien-module/prototypes/recipe/alien-module.lua
+++ b/alien-module/prototypes/recipe/alien-module.lua
@@ -8,7 +8,7 @@ data:extend({
 		energy_required = 10,
 		ingredients = { { type = "item", name = "artifact-ore", amount = 1 } },
 		results = { { type = "item", name = "alien-plate", amount = 1 } },
-		allowed_module_categories = { "productivity", "efficiency", "speed", "quality" }
+		allowed_module_categories = { "productivity", "efficiency", "speed" }
 	}
 })
 
@@ -159,7 +159,6 @@ for i = 1, 100, 1 do
 		{
 			type = "recipe",
 			name = "alien-hyper-module-" .. i,
-			category = "electronics",
 			enabled = false,
 			hidden_in_factoriopedia = true,
 			energy_required = i,
@@ -167,7 +166,18 @@ for i = 1, 100, 1 do
 			ingredients = {
 				{ type = "item", name = "alien-plate", amount = 20 * i }
 			},
-			allowed_module_categories = { "productivity", "efficiency", "speed", "quality" }
+			allowed_module_categories = { "productivity", "efficiency", "speed" }
 		},
 	})
+
+	--adds the electronics catagory to modules if spaceage is installed
+	if mods["space-age"] then
+		data.raw["recipe"]["alien-hyper-module-" .. i].category = "electronics"
+	end
+
+	-- allows quality modules if quality is installed
+	if mods["quality"] then
+		data.raw["recipe"]["alien-hyper-module-" .. i].allowed_module_categories = { "productivity", "efficiency", "speed", "quality" }
+		data.raw["recipe"]["alien-plate"].allowed_module_categories = { "productivity", "efficiency", "speed", "quality" }
+	end
 end


### PR DESCRIPTION
i took everything that used features from quality and space age and wrapped them in if statements, and they are now added via data.raw if the appropriate mod is enabled.

i didnt add them to the dependency list as optional dependencies, as i dont know what main version they are on.

i did include version number and changelog updates as well as my code updates. tested to run on my computer.