### PR TITLE
Updates ore recipes to recycle into themselves

### DIFF
--- a/alien-module/changelog.txt
+++ b/alien-module/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.1.1
+  Changes:
+    - Added setting for how ore conversion recipes should recycle
+    - New setting allows vanilla recycling behavior of ore recipes (iron ore → iron ore)
+    - Added Chinese (zh-CN) locale for additional mod settings
+---------------------------------------------------------------------------------------------------
 Version: 2.1.0
   Changes:
     - Removed dependency on Total Productivity

--- a/alien-module/info.json
+++ b/alien-module/info.json
@@ -1,7 +1,7 @@
 {
   "name": "alien-module",
   "title": "Alien Loot Economy",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": "sensenmann",
   "homepage": "https://github.com/renoth/factorio-alien-module",
   "description": "Makes alien units drop alien ore that can be smelted into alien metal, which can be used for all sorts of alien empowered items.",

--- a/alien-module/locale/en/names.cfg
+++ b/alien-module/locale/en/names.cfg
@@ -245,6 +245,7 @@ alien-module-hyper-module-effect=Hyper Module effect per level (default 0.01)
 alien-module-drop-amount=Alien ore drop amount in %
 alien-module-hyper-quality-enabled=Enable quality bonus for Hypermodules?
 alien-module-productivity-everything=Enable productivity bonus for all recipes?
+alien-module-ore-recycle-to-alien=Enable vanilla recycling for converted ores
 rampant-alienmodule-compat-max-count-turret=Max drop count from worms
 rampant-alienmodule-compat-max-count-spawner=Max drop count from spawners
 
@@ -256,3 +257,4 @@ alien-module-hyper-module-effect=Hyper Module effect per level (default 0.01, mi
 alien-module-drop-amount=Sets the amount of dropped alien ore in % (min=1, max=10000)
 alien-module-hyper-quality-enabled=Activate or deactivate the quality bonus. Disabling can help with unwanted quality clutter.
 alien-module-productivity-everything=Activate this to be able to put Hyper Modules into almost everyhing (very Cheaty)
+alien-module-ore-recycle-to-alien=When enabled, ore recipes recycle back into themselves (iron-ore → iron-ore). When disabled, ore recipes recycle back into alien ore (iron-ore → alien-ore).

--- a/alien-module/locale/zh-CN/alien-module_0.4.3.cfg
+++ b/alien-module/locale/zh-CN/alien-module_0.4.3.cfg
@@ -136,3 +136,25 @@ alien-module=虫子现在会掉落异星矿石，可以加工成一些新产品.
 
 module-upgraded=异星超级插件提升至: __1__级
 label=异星超级插件等级: __1__ 消灭异虫数量: __2__
+
+[mod-setting-name]
+alien-module-ore-conversion=启用矿石转换配方
+alien-module-hyper-ammo-enabled=启用异星超级弹药
+alien-module-level-exponent=等级指数（值越高升级越快，默认0.1）
+alien-module-hyper-module-effect=超级插件每级效果（默认0.01）
+alien-module-drop-amount=异星矿石掉落量百分比
+alien-module-hyper-quality-enabled=为超级插件启用品质奖励？
+alien-module-productivity-everything=为所有配方启用效率奖励？
+alien-module-ore-recycle-to-alien=为转换矿石启用原版回收机制
+rampant-alienmodule-compat-max-count-turret=蠕虫最大掉落数量
+rampant-alienmodule-compat-max-count-spawner=刷怪器最大掉落数量
+
+[mod-setting-description]
+alien-module-ore-conversion=启用将异星矿石转换为其他矿石的配方
+alien-module-hyper-ammo-enabled=如果不使用或觉得效果烦人可以禁用
+alien-module-level-exponent=设置升级曲线陡峭程度。\n0.1 = 9000万击杀达到100级\n0.122 = 1000万击杀达到100级\n0.15 = 150万击杀达到100级\n0.2 = 13万击杀达到100级
+alien-module-hyper-module-effect=超级插件每级效果（默认0.01，最小值=0.001，最大值=0.1）。效果会四舍五入到最近的百分比。
+alien-module-drop-amount=设置掉落异星矿石的数量百分比（最小值=1，最大值=10000）
+alien-module-hyper-quality-enabled=激活或停用品质奖励。禁用可以帮助避免不需要的品质混乱。
+alien-module-productivity-everything=激活此选项可将超级插件放入几乎所有东西（非常作弊）
+alien-module-ore-recycle-to-alien=当启用时，矿石配方像原版一样回收（铁矿石 → 铁矿石）。当禁用时（默认），矿石配方回收回异星矿石（铁矿石 → 异星矿石）。

--- a/alien-module/prototypes/recipe/alien-module.lua
+++ b/alien-module/prototypes/recipe/alien-module.lua
@@ -23,7 +23,8 @@ if (settings.startup["alien-module-ore-conversion"].value) then
 			enabled = true,
 			energy_required = 10,
 			ingredients = { { type = "item", name = "artifact-ore", amount = 1 } },
-			results = { { type = "item", name = "iron-ore", amount = 5 } }
+			results = { { type = "item", name = "iron-ore", amount = 5 } },
+			auto_recycle = false
 		}
 	})
 
@@ -35,7 +36,8 @@ if (settings.startup["alien-module-ore-conversion"].value) then
 			enabled = true,
 			energy_required = 10,
 			ingredients = { { type = "item", name = "artifact-ore", amount = 1 } },
-			results = { { type = "item", name = "copper-ore", amount = 5 } }
+			results = { { type = "item", name = "copper-ore", amount = 5 } },
+			auto_recycle = false
 		}
 	})
 
@@ -47,7 +49,8 @@ if (settings.startup["alien-module-ore-conversion"].value) then
 			enabled = true,
 			energy_required = 10,
 			ingredients = { { type = "item", name = "artifact-ore", amount = 1 } },
-			results = { { type = "item", name = "stone", amount = 5 } }
+			results = { { type = "item", name = "stone", amount = 5 } },
+			auto_recycle = false
 		}
 	})
 
@@ -59,7 +62,8 @@ if (settings.startup["alien-module-ore-conversion"].value) then
 			enabled = true,
 			energy_required = 20,
 			ingredients = { { type = "item", name = "artifact-ore", amount = 2 } },
-			results = { { type = "item", name = "uranium-ore", amount = 1 } }
+			results = { { type = "item", name = "uranium-ore", amount = 1 } },
+			auto_recycle = false
 		}
 	})
 
@@ -71,7 +75,8 @@ if (settings.startup["alien-module-ore-conversion"].value) then
 			enabled = true,
 			energy_required = 10,
 			ingredients = { { type = "item", name = "artifact-ore", amount = 1 } },
-			results = { { type = "item", name = "coal", amount = 5 } }
+			results = { { type = "item", name = "coal", amount = 5 } },
+			auto_recycle = false
 		}
 	})
 end

--- a/alien-module/prototypes/recipe/alien-module.lua
+++ b/alien-module/prototypes/recipe/alien-module.lua
@@ -24,7 +24,7 @@ if (settings.startup["alien-module-ore-conversion"].value) then
 			energy_required = 10,
 			ingredients = { { type = "item", name = "artifact-ore", amount = 1 } },
 			results = { { type = "item", name = "iron-ore", amount = 5 } },
-			auto_recycle = false
+			auto_recycle = not settings.startup["alien-module-ore-recycle-to-alien"].value
 		}
 	})
 
@@ -37,7 +37,7 @@ if (settings.startup["alien-module-ore-conversion"].value) then
 			energy_required = 10,
 			ingredients = { { type = "item", name = "artifact-ore", amount = 1 } },
 			results = { { type = "item", name = "copper-ore", amount = 5 } },
-			auto_recycle = false
+			auto_recycle = not settings.startup["alien-module-ore-recycle-to-alien"].value
 		}
 	})
 
@@ -50,7 +50,7 @@ if (settings.startup["alien-module-ore-conversion"].value) then
 			energy_required = 10,
 			ingredients = { { type = "item", name = "artifact-ore", amount = 1 } },
 			results = { { type = "item", name = "stone", amount = 5 } },
-			auto_recycle = false
+			auto_recycle = not settings.startup["alien-module-ore-recycle-to-alien"].value
 		}
 	})
 
@@ -63,7 +63,7 @@ if (settings.startup["alien-module-ore-conversion"].value) then
 			energy_required = 20,
 			ingredients = { { type = "item", name = "artifact-ore", amount = 2 } },
 			results = { { type = "item", name = "uranium-ore", amount = 1 } },
-			auto_recycle = false
+			auto_recycle = not settings.startup["alien-module-ore-recycle-to-alien"].value
 		}
 	})
 
@@ -76,7 +76,7 @@ if (settings.startup["alien-module-ore-conversion"].value) then
 			energy_required = 10,
 			ingredients = { { type = "item", name = "artifact-ore", amount = 1 } },
 			results = { { type = "item", name = "coal", amount = 5 } },
-			auto_recycle = false
+			auto_recycle = not settings.startup["alien-module-ore-recycle-to-alien"].value
 		}
 	})
 end

--- a/alien-module/settings.lua
+++ b/alien-module/settings.lua
@@ -8,8 +8,15 @@ data:extend({
 	},
 	{
 		type = "bool-setting",
-		name = "alien-module-hyper-ammo-enabled",
+		name = "alien-module-ore-recycle-to-alien",
 		order = "aa",
+		setting_type = "startup",
+		default_value = false
+	},
+	{
+		type = "bool-setting",
+		name = "alien-module-hyper-ammo-enabled",
+		order = "ab",
 		setting_type = "startup",
 		default_value = true
 	},


### PR DESCRIPTION
Currently, alien ore recipes overwrite the default recycling recipe for mined ores. 

I think this creates unexpected behavior, for example, mined stone ore will recycle into alien-ore, instead of stone ore. 

This PR adds a setting to let users decide the desired recycling behavior. The default state will preserve existing mod behavior (to not break things for existing users), and toggling the setting on will enable vanilla recycling behavior for ores. 

This allows things like quality ladders at the mining outpost to continue to work as they would in vanilla. 

This also improves compatibility with the [fair unlimited productivity](https://mods.factorio.com/mod/fair-unlimited-productivity) mod. 

**Old Behavior**
<img width="359" height="328" alt="Screenshot 2025-08-30 at 1 22 40 PM" src="https://github.com/user-attachments/assets/643c71fc-3c00-4722-98e9-2619e523dec5" />

**New Behavior**
<img width="322" height="334" alt="Screenshot 2025-08-30 at 1 25 22 PM" src="https://github.com/user-attachments/assets/b67d4a81-8bb3-47a5-a0be-841fd9395bac" />

**The new setting**
<img width="446" height="123" alt="Screenshot 2025-08-30 at 1 51 40 PM" src="https://github.com/user-attachments/assets/8519eefc-300e-4266-b450-d9b698e831d9" />
