### PR TITLE
Fixes recipe descriptions in game 

### DIFF
--- a/alien-module/locale/en/names.cfg
+++ b/alien-module/locale/en/names.cfg
@@ -219,6 +219,14 @@ alien-hyper-magazine-100=Alien Hyper Magazine Level 100
 [item-group-name]
 alien-module=Alien Items
 
+[recipe-name]
+alien-ore-to-iron-ore=Alien Ore to Iron Ore
+alien-ore-to-copper-ore=Alien Ore to Copper Ore
+alien-ore-to-stone=Alien Ore to Stone
+alien-ore-to-uranium-ore=Alien Ore to Uranium Ore
+alien-ore-to-coal=Alien Ore to Coal
+alien-artifact-to-ore=Convert Alien Artifact to Ore
+
 [entity-name]
 alien-solarpanel=Alien Solarpanel
 alien-accumulator=Alien Accumulator

--- a/alien-module/locale/zh-CN/alien-module_0.4.3.cfg
+++ b/alien-module/locale/zh-CN/alien-module_0.4.3.cfg
@@ -118,6 +118,14 @@ alien-magazine=异星弹匣
 
 alien-module=异星物品
 
+[recipe-name]
+alien-ore-to-iron-ore=异星矿石转铁矿石
+alien-ore-to-copper-ore=异星矿石转铜矿石
+alien-ore-to-stone=异星矿石转石料
+alien-ore-to-uranium-ore=异星矿石转铀矿石
+alien-ore-to-coal=异星矿石转煤
+alien-artifact-to-ore=转换异星神器为矿石
+
 [entity-name]
 
 alien-solarpanel=异星太阳能板


### PR DESCRIPTION
Ore conversion recipe names are broken in the game and show an "unknown key" error message

**Current**
<img width="422" height="363" alt="Screenshot 2025-08-30 at 2 02 11 PM" src="https://github.com/user-attachments/assets/12c59cb5-c778-482c-bcb8-f038e0cd73bd" />

**After fix**
<img width="415" height="360" alt="Screenshot 2025-08-30 at 2 11 17 PM" src="https://github.com/user-attachments/assets/e3c3d850-c6da-4da0-9845-4fd3a2fc57f3" />

I did not modify changelog and info.json, as it'll cause a merge conflict with the other PR. Happy to add a changelog entry if both PRs look good. 